### PR TITLE
[DUCK] SonaType发布

### DIFF
--- a/.apollo.yml
+++ b/.apollo.yml
@@ -1,0 +1,10 @@
+---
+duckling-server:
+  build:
+    target: release
+    command: 'bash duckling-fork-chinese/bin/package'
+    env:
+      jdk: 1.8
+  runtime:
+    start: "cd /home/work/app/duckling-server; bash bin/stop; bash bin/duckling-server"
+    stop: "cd /home/work/app/duckling-server; bash bin/stop"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+variables:
+  PROJECT_SSH_URL: "git@git.n.xiaomi.com:knowledge-base/minlp.git"
+  HOSTS: $DEPLOY_HOSTS
+
+before_script:
+  # - export LC_ALL="zh_CN.UTF-8" # 编码问题可能导致测试出错
+  - fusion-cli config --access-key $ACCESS_KEY --secret-key $SECRET_KEY
+
+stages:
+  - 测试
+  - 系统编译
+  - 系统部署
+
+build:
+  stage: 测试
+  script:
+    - cd duckling-fork-chinese
+    - sbt clean coverage test
+    - sbt coverageAggregate
+
+build_branch:
+  stage: 系统编译
+  script:
+    - fusion-cli release build --branch $CI_COMMIT_REF_NAME --version $CI_COMMIT_SHORT_SHA --code $PROJECT_SSH_URL --service $RELEASE_SERVICE --wait
+  only:
+    - main
+
+deploy_branch:
+  stage: 系统部署
+  script:
+    - fusion-cli release deploy --branch $CI_COMMIT_REF_NAME --version $CI_COMMIT_SHORT_SHA --pdl $RELEASE_PDL --job $RELEASE_JOB_NAME --service $RELEASE_SERVICE --hosts $HOSTS --wait
+  only:
+    - main
+  when: on_success

--- a/duckling-fork-chinese/README.md
+++ b/duckling-fork-chinese/README.md
@@ -133,7 +133,7 @@ Intellij IDEA的设置中打开`Editor -> Code Style -> Scala`，点击Scheme右
 只会发布core项目，其它的会跳过：
 
 ```scala
-sbt release
+sbt ci-release
 ```
 
 ## 4. 如何新增一个Dimension

--- a/duckling-fork-chinese/README.md
+++ b/duckling-fork-chinese/README.md
@@ -130,7 +130,14 @@ Intellij IDEA的设置中打开`Editor -> Code Style -> Scala`，点击Scheme右
 
 ## 3. 发布
 
-只会发布core项目，其它的会跳过：
+参照[olafurpg/sbt-ci-release](https://github.com/olafurpg/sbt-ci-release)，需要配置好环境变量后执行`ci-release`命令，就能发布到sonatype了。
+
+```
+PGP_PASSPHRASE=
+PGP_SECRET=
+SONATYPE_USERNAME=
+SONATYPE_PASSWORD=
+```
 
 ```scala
 sbt ci-release

--- a/duckling-fork-chinese/bin/package
+++ b/duckling-fork-chinese/bin/package
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd duckling-fork-chinese
+sbt "project server; runMain com.xiaomi.duckling.ranking.NaiveBayesRank naive_bayes.json"
+cp server/naive_bayes.json server/src/main/resources/
+sbt server/stage
+mkdir ../release
+cp -r server/target/universal/stage/* ../release
+cp bin/stop ../release/bin/

--- a/duckling-fork-chinese/bin/stop
+++ b/duckling-fork-chinese/bin/stop
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for pid in `jps -ml | grep com.xiaomi.duckling.server.DucklingApplication | awk '{print $1}'`; 
+do 
+    kill -9 $pid
+done

--- a/duckling-fork-chinese/build.sbt
+++ b/duckling-fork-chinese/build.sbt
@@ -1,10 +1,8 @@
 import Dependencies._
-import com.jsuereth.sbtpgp.SbtPgp.autoImport.PgpKeys.{publishLocalSigned, publishSigned}
-import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
-import sbtrelease.Utilities._
-import xerial.sbt.Sonatype.autoImport._
 
-// 大量参考了 Scalaz [[https://github.com/scalaz/scalaz]]项目的配置
+// 配置大量参考了
+// Scalaz [[https://github.com/scalaz/scalaz]]项目的配置
+// 以及 https://github.com/olafurpg/sbt-ci-release
 
 lazy val sharedSettings = Seq(
   organization := "com.xiaomi.duckling",
@@ -19,8 +17,6 @@ lazy val sharedSettings = Seq(
   ),
   Test / parallelExecution := false,
   run / fork := true,
-  Compile / coverageEnabled := false,
-  Test / coverageEnabled := true,
   // sbt run with provided scope
   Compile / run := Defaults
     .runTask(Compile / fullClasspath, Compile / run / mainClass, Compile / run / runner)
@@ -29,54 +25,14 @@ lazy val sharedSettings = Seq(
     .runMainTask(Compile / fullClasspath, Compile / run / runner)
     .evaluated,
 
-  // 远程仓库发布
-  pomExtra := <url>https://github.com/XiaoMi/MiNLP</url>
-    <licenses>
-      <license>
-        <name>Apache 2</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        <distribution>repo</distribution>
-        <comments>A business-friendly OSS license</comments>
-      </license>
-    </licenses>
-    <developers>
-      <developer>
-        <id>du00cs</id>
-        <name>Ninglin Du</name>
-        <url>https://github.com/du00cs</url>
-      </developer>
-      <developer>
-        <id>zhangsonglei</id>
-        <name>Songlei Zhang</name>
-        <url>https://github.com/zhangsonglei</url>
-      </developer>
-    </developers>,
-  licenseFile := (ThisBuild / baseDirectory).value / "LICENSE",
-  credentialsSetting,
-  publishTo := sonatypePublishToBundle.value,
-  Test / publishArtifact := false,
-  // git发布
-  releaseIgnoreUntrackedFiles := true,
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    releaseStepCommandAndRemaining("set ThisBuild / useSuperShell := false"),
-    publishSignedArtifacts,
-    releaseStepCommand(s"rootNative/publishSigned"),
-    releaseStepCommandAndRemaining("set ThisBuild / useSuperShell := true"),
-    releaseStepCommandAndRemaining("sonatypeBundleRelease"),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
-) ++ Seq(packageBin, packageDoc, packageSrc).flatMap {
-  // include LICENSE in all packaged artifacts
-  inTask(_)(Seq((Compile / mappings) += licenseFile.value -> "LICENSE"))
-}
+  homepage := Some(url("https://github.com/XiaoMi/MiNLP/tree/main/duckling-fork-chinese")),
+  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  developers := List(
+    Developer("du00cs", "Ninglin Du", "duninglin@xiaomi.com", url("https://github.com/du00cs")),
+    Developer("zhangsonglei", "Songlei Zhang", "zhangsonglei@xiaomi.com", url("https://github.com/zhangsonglei"))
+  ),
+  Test / publishArtifact := false
+)
 
 lazy val compilerOptions = Seq(
   "-unchecked",
@@ -90,63 +46,17 @@ lazy val compilerOptions = Seq(
   "utf8"
 )
 
-lazy val noPublishSettings = Seq(
-  publishArtifact := false,
-  publish := {},
-  publishLocal := {},
-  publishSigned := {},
-  publishLocalSigned := {}
-)
+publish / skip := true // don't publish the root project
 
-lazy val publishSignedArtifacts = ReleaseStep(
-  action = st => {
-    val extracted = st.extract
-    val ref = extracted.get(thisProjectRef)
-    extracted.runAggregated(ref / (Global / publishSigned), st)
-  },
-  check = st => {
-    // getPublishTo fails if no publish repository is set up.
-    val ex = st.extract
-    val ref = ex.get(thisProjectRef)
-    val (newState, value) = ex.runTask(ref / (Global / publishTo), st)
-    Classpaths.getPublishTo(value)
-    newState
-  },
-  enableCrossBuild = true
-)
-
-lazy val credentialsSetting = credentials ++= {
-  val name = "Sonatype Nexus Repository Manager"
-  val realm = "oss.sonatype.org"
-  (
-    sys.props.get("build.publish.user"),
-    sys.props.get("build.publish.password"),
-    sys.env.get("SONATYPE_USERNAME"),
-    sys.env.get("SONATYPE_PASSWORD")
-  ) match {
-    case (Some(user), Some(pass), _, _) => Seq(Credentials(name, realm, user, pass))
-    case (_, _, Some(user), Some(pass)) => Seq(Credentials(name, realm, user, pass))
-    case _ =>
-      val ivyFile = Path.userHome / ".ivy2" / ".credentials"
-      val m2File = Path.userHome / ".m2" / "credentials"
-      if (ivyFile.exists()) Seq(Credentials(ivyFile))
-      else if (m2File.exists()) Seq(Credentials(m2File))
-      else Nil
-  }
-}
-
-lazy val licenseFile = settingKey[File]("The license file to include in packaged artifacts")
-
-lazy val global = project.in(file(".")).settings(sharedSettings)
-  .settings(noPublishSettings)
+lazy val `duckling-fork-chinese` = project.in(file("."))
+  .settings(sharedSettings)
   .aggregate(core, server, benchmark)
 
 lazy val core = project
   .settings(
     name := "duckling-core",
     sharedSettings,
-    libraryDependencies ++= coreDependencies,
-    publishArtifact := true
+    libraryDependencies ++= coreDependencies
   )
 
 lazy val server = project
@@ -154,11 +64,11 @@ lazy val server = project
     name := "duckling-server",
     sharedSettings,
     libraryDependencies ++= serverDependencies,
+    publish / skip := true,
     // 打包
     Universal / javaOptions ++= Seq("-J-Xmx1g"),
     scriptClasspath := Seq("../conf", "*")
   )
-  .settings(noPublishSettings)
   .dependsOn(core)
   .enablePlugins(JavaServerAppPackaging)
 
@@ -167,10 +77,10 @@ lazy val benchmark = project
     name := "duckling-benchmark",
     sharedSettings,
     libraryDependencies ++= benchmarkDependencies,
+    publish / skip := true,
     outputStrategy := Some(StdoutOutput),
     fork := true,
     connectInput := true,
     logBuffered := false
   )
-  .settings(noPublishSettings)
   .dependsOn(core)

--- a/duckling-fork-chinese/project/plugins.sbt
+++ b/duckling-fork-chinese/project/plugins.sbt
@@ -1,10 +1,9 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.21")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 
 // coverage
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")


### PR DESCRIPTION
进行了大幅简化，自动版本号之类的功能没做，需要手动打TAG。

验证了内外部库可以统一走来，发布是可以统一的。引入了小米内部部署需要的配置文件。