### PR TITLE
[DUCK] 增加cross build，适应性更新依赖版本号

### DIFF
--- a/.github/workflows/duckling.yml
+++ b/.github/workflows/duckling.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Run tests
       run: |
         cd duckling-fork-chinese
-        sbt clean coverage test
+        sbt +test
+        sbt coverage
         sbt coverageAggregate
         bash <(curl -s https://codecov.io/bash) -r du00cs/MiNLP -t 'd2de025e-e5b7-4115-a98e-07e6fc3d7001'

--- a/duckling-fork-chinese/build.sbt
+++ b/duckling-fork-chinese/build.sbt
@@ -8,7 +8,7 @@ lazy val sharedSettings = Seq(
   organization := "com.xiaomi.duckling",
   scalaVersion := "2.11.12",
   // cross scala versions 还需要摸索
-  // crossScalaVersions := Seq("2.11.12", "2.12.12"),
+  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.8"),
   scalacOptions ++= compilerOptions,
   resolvers ++= Seq(
     Resolver.mavenLocal, // 加速

--- a/duckling-fork-chinese/build.sbt
+++ b/duckling-fork-chinese/build.sbt
@@ -7,7 +7,6 @@ import Dependencies._
 lazy val sharedSettings = Seq(
   organization := "com.xiaomi.duckling",
   scalaVersion := "2.11.12",
-  // cross scala versions 还需要摸索
   crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.8"),
   scalacOptions ++= compilerOptions,
   resolvers ++= Seq(

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/age/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/age/Rules.scala
@@ -32,7 +32,7 @@ trait Rules extends DimRules {
     prod = tokens {
       case t1 :: Token(_, GroupMatch(s :: _)) :: _ =>
         for (i <- getIntValue(t1)) yield {
-          val n = if (s.endsWith("半")) i + 0.5 else i
+          val n: Double = if (s.endsWith("半")) i + 0.5 else i
           token(NumeralValue(n))
         }
     }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/currency/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/currency/Rules.scala
@@ -34,9 +34,9 @@ trait Rules extends DimRules {
       case t1 :: Token(_, GroupMatch(s0 :: s :: _)) :: _ =>
         for (v <- getIntValue(t1)) yield {
           val scalar = s match {
-            case "元" | "块" => 1
-            case "角" | "毛" =>.1
-            case "分" =>.01
+            case "元" | "块" => 1.0
+            case "角" | "毛" => 0.1
+            case "分" => 0.01
           }
           token(CurrencyData(v, scalar, s, end = s0.endsWith("钱"), code = RMB))
         }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/episode/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/episode/Rules.scala
@@ -32,7 +32,7 @@ trait Rules extends DimRules {
     pattern = List(notEndsWithGe.predicate, episodePattern),
     prod = tokens {
       case t1 :: _ =>
-        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(i, "集", "集"))
+        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(i.toDouble, "集", "集"))
     }
   )
 
@@ -41,7 +41,7 @@ trait Rules extends DimRules {
     pattern = List(isNatural.predicate, episodePattern),
     prod = tokens {
       case t1 :: _ =>
-        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(i, "集", "集", true))
+        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(i.toDouble, "集", "集", true))
     }
   )
 
@@ -50,7 +50,7 @@ trait Rules extends DimRules {
     pattern = List(reversePattern, isNatural.predicate, episodePattern),
     prod = tokens {
       case _ :: t1 :: _ =>
-        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(-i, "集", "集"))
+        for (i <- getIntValue(t1)) yield Token(Episode, QuantityData(-i.toDouble, "集", "集"))
     }
   )
 }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/level/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/level/Rules.scala
@@ -27,7 +27,7 @@ trait Rules extends DimRules {
     name = "<ordinal> level",
     pattern = List(notEndsWithGe.predicate, "(级(?!别)|档)".regex),
     prod = tokens {
-      case Token(_, OrdinalData(value, _)) :: _ => Token(Level, NumeralData(value))
+      case Token(_, OrdinalData(value, _)) :: _ => Token(Level, NumeralData(value.toDouble))
     }
   )
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Prods.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Prods.scala
@@ -98,7 +98,7 @@ object Prods {
       "Ⅸ" -> 9
     )
 
-  def long(x: Long): Option[Token] = double(x)
+  def long(x: Long): Option[Token] = double(x.toDouble)
 
   def parseDecimal(`match`: String, precision: Int): Option[Token] = {
     parseDouble(`match`).toOption.flatMap(x => double(x, precision))

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Rules.scala
@@ -37,8 +37,9 @@ trait Rules extends DimRules {
     name = "integer (numeric)",
     pattern = List("(0|[1-9]\\d{0,17})".regex),
     prod = singleRegexMatch { case t =>
-      parseLong(t).toOption.flatMap(long).map{ case Token(dim, nd: NumeralData) =>
-        Token(dim, nd.copy(sequence = t))
+      parseLong(t).toOption.flatMap(long).map {
+        case Token(dim, nd: NumeralData) => Token(dim, nd.copy(sequence = t))
+        case t => t // suppress warning
       }
     }
   )

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Types.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Types.scala
@@ -262,11 +262,11 @@ object Types {
   }
 
   case class DuckDateTime(date: DuckDate, time: LocalTime, zone: ZoneId) {
-    def this(dt: ZonedDateTime) {
+    def this(dt: ZonedDateTime) = {
       this(SolarDate(dt.toLocalDate), dt.toLocalTime, dt.getZone)
     }
 
-    def this(dt: LocalDateTime, zone: ZoneId = ZoneCN) {
+    def this(dt: LocalDateTime, zone: ZoneId = ZoneCN) = {
       this(dt.atZone(zone))
     }
 
@@ -389,7 +389,7 @@ object Types {
       extends SingleTimeValue
 
   case class TimeObject(start: DuckDateTime, grain: Grain, end: Option[DuckDateTime] = None) {
-    def this(ref: ZonedDateTime, grain: Grain) {
+    def this(ref: ZonedDateTime, grain: Grain) = {
       this(new DuckDateTime(ref), grain)
     }
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/rule/FuzzyDayIntervals.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/rule/FuzzyDayIntervals.scala
@@ -18,8 +18,8 @@ package com.xiaomi.duckling.dimension.time.rule
 
 import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.implicits._
-import com.xiaomi.duckling.dimension.matcher.GroupMatch
 import com.xiaomi.duckling.dimension.matcher.Prods._
+import com.xiaomi.duckling.dimension.time.{Time, TimeData}
 import com.xiaomi.duckling.dimension.time.Prods._
 import com.xiaomi.duckling.dimension.time.enums.Grain._
 import com.xiaomi.duckling.dimension.time.enums.Hint
@@ -27,8 +27,7 @@ import com.xiaomi.duckling.dimension.time.enums.Hint._
 import com.xiaomi.duckling.dimension.time.enums.IntervalType.Open
 import com.xiaomi.duckling.dimension.time.form.{IntervalOfDay, PartOfDay, TimeOfDay}
 import com.xiaomi.duckling.dimension.time.helper.TimeDataHelpers._
-import com.xiaomi.duckling.dimension.time.predicates.{SequencePredicate, TimeDatePredicate, TimeIntervalsPredicate, _}
-import com.xiaomi.duckling.dimension.time.{timeSeqMap, Time, TimeData}
+import com.xiaomi.duckling.dimension.time.predicates._
 
 object FuzzyDayIntervals {
 
@@ -110,6 +109,7 @@ object FuzzyDayIntervals {
       case (IntersectTimePredicate(_: TimeIntervalsPredicate, series: SeriesPredicate), Some(time)) =>
         tt(td.copy(timePred = IntersectTimePredicate(time.timePred, series)))
       case (_: TimeIntervalsPredicate, Some(time)) => tt(time)
+      case _ => None
     }
   }
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/engine/Stash.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/engine/Stash.scala
@@ -22,7 +22,7 @@ import com.xiaomi.duckling.engine
 import com.xiaomi.duckling.types.Node
 
 case class Stash(getSet: SortedMap[Int, Set[Node]]) {
-  def filter(p: Node => Boolean): Stash = engine.Stash(getSet.mapValues(_ filter p))
+  def filter(p: Node => Boolean): Stash = engine.Stash(getSet.map { case (k, v) => (k, v filter p) })
 
   def isEmpty: Boolean = getSet.isEmpty
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/AnswersSelection.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/AnswersSelection.scala
@@ -148,7 +148,7 @@ object AnswersSelection extends LazyLogging {
       .flatMap(a => a.dim.combinationFeatures(a.token.node))
       .map(f => f.name())
       .groupBy(s => s)
-      .mapValues(_.size)
+      .fmap(_.size)
   }
 
   def parse(sentence: String, dim: Dimension) = {

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/Bayes.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/Bayes.scala
@@ -17,6 +17,7 @@
 package com.xiaomi.duckling.ranking
 
 import com.xiaomi.duckling.ranking.Types.{BagOfFeatures, Class, Datum}
+import scalaz.Scalaz._
 
 object Bayes {
 
@@ -37,7 +38,7 @@ object Bayes {
     val prior = math.log(1.0 * (classTotal + 1e-9) / total)
     val denum = vocSize + feats.values.sum
     val unseen = math.log(1.0 / (denum + 1.0))
-    val likelihoods = feats.mapValues(x => math.log((x + 1.0) / denum))
+    val likelihoods = feats.fmap(x => math.log((x + 1.0) / denum))
 
     ClassData(prior, unseen, likelihoods, classTotal)
   }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/task/CombinationDiff.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/task/CombinationDiff.scala
@@ -42,7 +42,7 @@ object CombinationDiff {
   def main(args: Array[String]): Unit = {
     val lines = Files.readAllLines(Paths.get("factoid_query.txt"), StandardCharsets.UTF_8).asScala
     val writer = Files.newBufferedWriter(Paths.get("time.diff"), StandardCharsets.UTF_8)
-    lines.par.foreach { line =>
+    lines.foreach { line =>
       val s0 = Api.analyze(line, Testing.testContext, options0).map(_.text).mkString("/")
       val s1 = Api.analyze(line, Testing.testContext, options1).map(_.text).mkString("/")
       if (s0 != s1) {

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/ApiTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/ApiTest.scala
@@ -21,7 +21,6 @@ import com.xiaomi.duckling.dimension.currency.Currency
 import com.xiaomi.duckling.dimension.episode.Episode
 import com.xiaomi.duckling.dimension.level.Level
 import com.xiaomi.duckling.dimension.numeral.fraction.{Fraction, FractionData}
-import org.scalatest.{FunSpec, Matchers}
 import com.xiaomi.duckling.dimension.numeral.{DoubleSideIntervalValue, Numeral, NumeralValue, OpenIntervalValue}
 import com.xiaomi.duckling.dimension.ordinal.{Ordinal, OrdinalData}
 import com.xiaomi.duckling.dimension.quantity.QuantityValue
@@ -33,7 +32,7 @@ import com.xiaomi.duckling.dimension.time.duration.Duration
 import com.xiaomi.duckling.dimension.time.date.Date
 
 
-class ApiTest extends FunSpec with Matchers {
+class ApiTest extends UnitSpec {
 
   import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
 
@@ -57,9 +56,9 @@ class ApiTest extends FunSpec with Matchers {
           Api.analyze(query, testContext, options).foreach{
             answer =>
               answer.token.value match {
-                case data: DoubleSideIntervalValue  => println(data.schema())
-                case data: NumeralValue  => println(data.schema())
-                case data: OpenIntervalValue  => println(data.schema())
+                case data: DoubleSideIntervalValue  => println(data.schema)
+                case data: NumeralValue  => println(data.schema)
+                case data: OpenIntervalValue  => println(data.schema)
                 case _ => println("error")
               }
           }

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/DocumentTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/DocumentTest.scala
@@ -16,11 +16,9 @@
 
 package com.xiaomi.duckling
 
-import org.scalatest.{FunSpec, Matchers}
-
 import com.xiaomi.duckling.analyzer.HanlpAnalyzer
 
-class DocumentTest extends FunSpec with Matchers {
+class DocumentTest extends UnitSpec {
 
   describe("DocumentTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/EngineTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/EngineTest.scala
@@ -16,15 +16,12 @@
 
 package com.xiaomi.duckling
 
-import com.xiaomi.duckling.dimension.matcher.RegexMatch
-import org.scalatest.{FunSpec, Matchers}
 import com.xiaomi.duckling.Types._
-import com.xiaomi.duckling.dimension.implicits._
 import com.xiaomi.duckling.dimension.matcher.{GroupMatch, RegexMatch}
 import com.xiaomi.duckling.engine.RegexLookup._
 import com.xiaomi.duckling.types.Node
 
-class EngineTest extends FunSpec with Matchers {
+class EngineTest extends UnitSpec {
 
   describe("EngineTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/UnitSpec.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/UnitSpec.scala
@@ -1,0 +1,7 @@
+package com.xiaomi.duckling
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+abstract class UnitSpec extends AnyFunSpec with Matchers with TableDrivenPropertyChecks

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/constraints/TokenSpanTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/constraints/TokenSpanTest.scala
@@ -16,15 +16,13 @@
 
 package com.xiaomi.duckling.constraints
 
-import org.scalatest.{FunSpec, Matchers}
-
-import com.xiaomi.duckling.{Api, Types}
+import com.xiaomi.duckling.{Api, Types, UnitSpec}
 import com.xiaomi.duckling.Types.{Context, Options}
 import com.xiaomi.duckling.dimension.place.Place
 import com.xiaomi.duckling.dimension.time.Time
 import com.xiaomi.duckling.types.{LanguageInfo, TokenLabel}
 
-class TokenSpanTest extends FunSpec with Matchers {
+class TokenSpanTest extends UnitSpec {
 
   describe("TokenSpan") {
     it("testIsValid") {

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/GeneralCaseTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/GeneralCaseTest.scala
@@ -16,16 +16,17 @@
 
 package com.xiaomi.duckling.dimension
 
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks
+
 import com.typesafe.scalalogging.LazyLogging
+
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
 import com.xiaomi.duckling.task.NaiveBayesDebug
+import com.xiaomi.duckling.UnitSpec
 
 class GeneralCaseTest
-    extends FunSpec
-    with Matchers
+    extends UnitSpec
     with TableDrivenPropertyChecks
     with LazyLogging {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/age/AgeTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/age/AgeTest.scala
@@ -19,10 +19,9 @@ package com.xiaomi.duckling.dimension.age
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.numeral.{DoubleSideIntervalValue, NumeralValue, OpenIntervalValue}
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
+import com.xiaomi.duckling.UnitSpec
 
-class AgeTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class AgeTest extends UnitSpec {
 
 	val options = testOptions.copy(targets = Set(Age), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/currency/CurrencyTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/currency/CurrencyTest.scala
@@ -19,10 +19,9 @@ package com.xiaomi.duckling.dimension.currency
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.quantity.QuantityValue
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class CurrencyTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class CurrencyTest extends UnitSpec{
 
 	val options = testOptions.copy(targets = Set(Currency), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/episode/EpisodeTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/episode/EpisodeTest.scala
@@ -16,14 +16,12 @@
 
 package com.xiaomi.duckling.dimension.episode
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.quantity.QuantityValue
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
+import com.xiaomi.duckling.UnitSpec
 
-class EpisodeTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class EpisodeTest extends UnitSpec {
 
 	val options = testOptions.copy(targets = Set(Episode), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/level/LevelTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/level/LevelTest.scala
@@ -19,10 +19,9 @@ package com.xiaomi.duckling.dimension.level
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.numeral.NumeralValue
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class LevelTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class LevelTest extends UnitSpec{
 
 	val options = testOptions.copy(targets = Set(Level), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/music/LyricTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/music/LyricTest.scala
@@ -16,10 +16,9 @@
 
 package com.xiaomi.duckling.dimension.music
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
+import com.xiaomi.duckling.UnitSpec
 
-class LyricTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class LyricTest extends UnitSpec {
 
   describe("LyricTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/numeral/NumeralTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/numeral/NumeralTest.scala
@@ -22,10 +22,9 @@ import com.xiaomi.duckling.dimension.numeral.Predicates._
 import com.xiaomi.duckling.dimension.numeral.fraction.{Fraction, FractionData}
 import com.xiaomi.duckling.dimension.ordinal.{Ordinal, OrdinalData}
 import com.xiaomi.duckling.ranking.Testing._
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class NumeralTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class NumeralTest extends UnitSpec {
 
   val options = testOptions.copy(
     targets = Set(Numeral),

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/place/PlaceTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/place/PlaceTest.scala
@@ -16,14 +16,12 @@
 
 package com.xiaomi.duckling.dimension.place
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.Types.Answer
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
+import com.xiaomi.duckling.UnitSpec
 
-class PlaceTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class PlaceTest extends UnitSpec {
   val options = testOptions.copy(targets = Set(Place))
 
   def placeAnalyze(sentence: String): Answer = {

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/quantity/QuantityTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/quantity/QuantityTest.scala
@@ -16,14 +16,12 @@
 
 package com.xiaomi.duckling.dimension.quantity
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.numeral.{Numeral, NumeralValue}
+import com.xiaomi.duckling.UnitSpec
 
-class QuantityTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class QuantityTest extends UnitSpec {
 
   val options = testOptions.copy(targets = Set(Quantity))
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/rating/RatingTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/rating/RatingTest.scala
@@ -16,15 +16,13 @@
 
 package com.xiaomi.duckling.dimension.rating
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.answerSize
 import com.xiaomi.duckling.dimension.numeral.{DoubleSideIntervalValue, NumeralValue, OpenIntervalValue}
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
+import com.xiaomi.duckling.UnitSpec
 
-class RatingTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class RatingTest extends UnitSpec {
 
 	val options = testOptions.copy(targets = Set(Rating), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/season/SeasonTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/season/SeasonTest.scala
@@ -19,10 +19,9 @@ package com.xiaomi.duckling.dimension.season
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.dimension.quantity.QuantityValue
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class SeasonTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class SeasonTest extends UnitSpec {
 
 	val options = testOptions.copy(targets = Set(Season), full = false)
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/temperature/TemperatureTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/temperature/TemperatureTest.scala
@@ -16,16 +16,14 @@
 
 package com.xiaomi.duckling.dimension.temperature
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.Types.Answer
 import com.xiaomi.duckling.dimension.answerSize
 import com.xiaomi.duckling.dimension.quantity.QuantityValue
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
+import com.xiaomi.duckling.UnitSpec
 
-class TemperatureTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class TemperatureTest extends UnitSpec {
 
   val options = testOptions.copy(targets = Set(Temperature))
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeDataTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeDataTest.scala
@@ -16,19 +16,17 @@
 
 package com.xiaomi.duckling.dimension.time
 
-import org.scalatest.{FunSpec, Matchers}
-
 import com.typesafe.scalalogging.LazyLogging
 
 import com.xiaomi.duckling.Api.analyze
-import com.xiaomi.duckling.dimension.time.Types._
-import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.implicits._
+import com.xiaomi.duckling.dimension.time.Types._
 import com.xiaomi.duckling.dimension.time.enums.Grain
 import com.xiaomi.duckling.dimension.time.predicates.TimeDatePredicate
 import com.xiaomi.duckling.ranking.Testing.{testContext, testOptions}
+import com.xiaomi.duckling.UnitSpec
 
-class TimeDataTest extends FunSpec with Matchers with LazyLogging {
+class TimeDataTest extends UnitSpec with LazyLogging {
 
   describe("TimeDataTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeTest.scala
@@ -18,9 +18,6 @@ package com.xiaomi.duckling.dimension.time
 
 import java.time.{LocalDateTime, ZonedDateTime}
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.TableDrivenPropertyChecks
-
 import com.xiaomi.duckling.Api.analyze
 import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.time.Types.{InstantValue, SimpleValue}
@@ -29,8 +26,9 @@ import com.xiaomi.duckling.dimension.time.helper.TimeDataHelpers._
 import com.xiaomi.duckling.dimension.time.predicates.ReplacePartPredicate
 import com.xiaomi.duckling.ranking.Testing
 import com.xiaomi.duckling.ranking.Testing._
+import com.xiaomi.duckling.UnitSpec
 
-class TimeTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
+class TimeTest extends UnitSpec {
 
   private val options = testOptions.copy(targets = Set(Time))
   private val combinationOptions =

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TypesTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TypesTest.scala
@@ -18,17 +18,18 @@ package com.xiaomi.duckling.dimension.time
 
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
 
-import org.scalatest.{FunSpec, Matchers}
 import com.github.heqiao2010.lunar.LunarCalendar
+
 import com.xiaomi.duckling.dimension.time.enums.Grain.Day
 import com.xiaomi.duckling.dimension.time.helper.TimeDataHelpers._
 import com.xiaomi.duckling.dimension.time.helper.TimeObjectHelpers.{timeIntersect, timePlus}
-import com.xiaomi.duckling.dimension.time.Types.{DuckDateTime, LunarDate, SolarDate, TimeContext, TimeObject}
+import com.xiaomi.duckling.dimension.time.Types._
 import com.xiaomi.duckling.dimension.time.enums.Grain
 import com.xiaomi.duckling.ranking.Testing
 import com.xiaomi.duckling.Types.ZoneCN
+import com.xiaomi.duckling.UnitSpec
 
-class TypesTest extends FunSpec with Matchers {
+class TypesTest extends UnitSpec {
 
   describe("TypesTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/date/RulesTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/date/RulesTest.scala
@@ -18,9 +18,9 @@ package com.xiaomi.duckling.dimension.time.date
 
 import scala.util.matching.Regex
 
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class RulesTest extends FunSpec with Matchers {
+class RulesTest extends UnitSpec{
 
   object NoopRule extends Rules {}
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/grain/TimeGrainTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/grain/TimeGrainTest.scala
@@ -16,13 +16,13 @@
 
 package com.xiaomi.duckling.dimension.time.grain
 
-import com.xiaomi.duckling.Api
+import com.xiaomi.duckling.{Api, UnitSpec}
 import com.xiaomi.duckling.dimension.time.Time
 import com.xiaomi.duckling.dimension.time.duration.Duration
 import com.xiaomi.duckling.ranking.Testing
-import org.scalatest.{FunSpec, Matchers}
 
-class TimeGrainTest extends FunSpec with Matchers {
+
+class TimeGrainTest extends UnitSpec {
   describe("TimeGrain") {
     it("正则匹配周") {
       val r = WeekPattern.r

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/rule/FuzzyDayIntervalsTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/rule/FuzzyDayIntervalsTest.scala
@@ -16,19 +16,16 @@
 
 package com.xiaomi.duckling.dimension.time.rule
 
-import org.scalatest.FunSpec
-
+import com.xiaomi.duckling.dimension.implicits._
 import com.xiaomi.duckling.dimension.time.enums.Grain.Hour
 import com.xiaomi.duckling.dimension.time.TimeData
-import com.xiaomi.duckling.dimension.time.Types._
-import com.xiaomi.duckling.Types._
-import com.xiaomi.duckling.dimension.implicits._
 import com.xiaomi.duckling.dimension.time.form.TimeOfDay
 import com.xiaomi.duckling.dimension.time.helper.TimeDataHelpers._
 import com.xiaomi.duckling.dimension.time.predicates.{SequencePredicate, TimeDatePredicate}
 import com.xiaomi.duckling.ranking.Testing
+import com.xiaomi.duckling.UnitSpec
 
-class FuzzyDayIntervalsTest extends FunSpec {
+class FuzzyDayIntervalsTest extends UnitSpec {
 
   describe("FuzzyDayIntervalsTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/engine/LexiconLookupTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/engine/LexiconLookupTest.scala
@@ -1,10 +1,10 @@
 package com.xiaomi.duckling.engine
 
-import com.xiaomi.duckling.Document
+import com.xiaomi.duckling.{Document, UnitSpec}
 import com.xiaomi.duckling.dimension.gender.Gender
-import org.scalatest.{FunSpec, Matchers}
 
-class LexiconLookupTest extends FunSpec with Matchers {
+
+class LexiconLookupTest extends UnitSpec {
 
   describe("LexiconLookupTest") {
     it("should lookupLexiconAnywhere") {

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/engine/VarcharLookupTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/engine/VarcharLookupTest.scala
@@ -16,12 +16,12 @@
 
 package com.xiaomi.duckling.engine
 
-import org.scalatest.{FunSpec, Matchers}
 
-import com.xiaomi.duckling.Document
+
+import com.xiaomi.duckling.{Document, UnitSpec}
 import com.xiaomi.duckling.Types.DefaultExcludes
 
-class VarcharLookupTest extends FunSpec with Matchers {
+class VarcharLookupTest extends UnitSpec {
 
   describe("VarcharLookupTest") {
 

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/ranking/example/JsonSerdeTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/ranking/example/JsonSerdeTest.scala
@@ -17,14 +17,13 @@
 package com.xiaomi.duckling.ranking.example
 
 import org.json4s.jackson.Serialization.write
-import org.scalatest.{FunSpec, Matchers}
 
-import com.xiaomi.duckling.{Api, Types}
+import com.xiaomi.duckling.{Api, Types, UnitSpec}
 import com.xiaomi.duckling.JsonSerde._
 import com.xiaomi.duckling.dimension.numeral.Numeral
 import com.xiaomi.duckling.ranking.Testing
 
-class JsonSerdeTest extends FunSpec with Matchers {
+class JsonSerdeTest extends UnitSpec {
 
   describe("JsonSerdeTest") {
     it("should serialize entity") {

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/task/PlaceExtractorTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/task/PlaceExtractorTest.scala
@@ -16,9 +16,10 @@
 
 package com.xiaomi.duckling.task
 
-import org.scalatest.{FunSpec, Matchers}
+import com.xiaomi.duckling.UnitSpec
 
-class PlaceExtractorTest extends FunSpec with Matchers {
+
+class PlaceExtractorTest extends UnitSpec {
 
   describe("PlaceExtractorTest") {
     it("testExtract") {

--- a/duckling-fork-chinese/project/Dependencies.scala
+++ b/duckling-fork-chinese/project/Dependencies.scala
@@ -50,23 +50,23 @@ object Dependencies {
   lazy val junit = "junit" % "junit" % "4.12"
   lazy val hamcrest = "org.hamcrest" % "hamcrest" % "2.2"
   lazy val junitInterface = "com.novocode" % "junit-interface" % "0.11"
-  lazy val scalatic = "org.scalactic" %% "scalactic" % "3.0.5"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+  lazy val scalatic = "org.scalactic" %% "scalactic" % "3.2.10"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10"
   lazy val scalaMeter = "com.storm-enroute" %% "scalameter" % "0.18"
   lazy val jmhAnn = "org.openjdk.jmh" % "jmh-generator-annprocess" % "1.21"
   lazy val jmhCore = "org.openjdk.jmh" % "jmh-core" % "1.21"
 
-  lazy val json4sJackson = "org.json4s" %% "json4s-jackson" % "3.6.5"
+  lazy val json4sJackson = "org.json4s" %% "json4s-jackson" % "3.6.12"
   lazy val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4"
   // logger
   lazy val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.26"
   lazy val slf4jnop = "org.slf4j" % "slf4j-nop" % "1.7.26"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
-  lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
+  lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
 
   // utils
   lazy val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.27"
-  lazy val arm = "com.jsuereth" %% "scala-arm" % "2.0"
+  lazy val arm = "com.michaelpollmeier" %% "scala-arm" % "2.1"
   lazy val commonslang = "org.apache.commons" % "commons-lang3" % "3.7"
   lazy val commonsText = "org.apache.commons" % "commons-text" % "1.9"
   lazy val commonsIO = "commons-io" % "commons-io" % "2.6"

--- a/duckling-fork-chinese/project/build.properties
+++ b/duckling-fork-chinese/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.6.2

--- a/duckling-fork-chinese/server/src/test/scala/com/xiaomi/duckling/PlaceQueryTest.scala
+++ b/duckling-fork-chinese/server/src/test/scala/com/xiaomi/duckling/PlaceQueryTest.scala
@@ -16,9 +16,10 @@
 
 package com.xiaomi.duckling
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PlaceQueryTest extends FunSpec with Matchers {
+class PlaceQueryTest extends AnyFunSpec with Matchers {
   describe("PlaceQuery") {
     it("levels") {
       PlaceQuery.extract("山东") shouldBe Some("中华人民共和国/山东省")


### PR DESCRIPTION
1. 增加scala 2.11/2.12/2.13 交叉编译，准备发多版本的包
2. Scala 2.13需要更新一些包
3. Scalatest测试简化