### PR TITLE
[DUCK] 更新词典匹配为前缀树匹配

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/gender/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/gender/Rules.scala
@@ -16,7 +16,7 @@
 
 package com.xiaomi.duckling.dimension.gender
 
-import com.google.common.collect.ImmutableListMultimap
+import com.google.common.collect.{ImmutableListMultimap, Maps}
 
 import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.DimRules
@@ -27,7 +27,7 @@ import com.xiaomi.duckling.engine.LexiconLookup.Dict
 trait Rules extends DimRules {
 
   val dict = {
-    val builder = ImmutableListMultimap.builder[String, String]()
+    val builder = Maps.newTreeMap[String, String]()
     builder.put("女", "女")
     builder.put("女性", "女")
     builder.put("女生", "女")
@@ -36,8 +36,7 @@ trait Rules extends DimRules {
     builder.put("男性", "男")
     builder.put("男生", "男")
     builder.put("男孩", "男")
-
-    Dict(vocab = builder.build())
+    new Dict(builder, false)
   }
 
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/helper/HolidayProvider.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/helper/HolidayProvider.scala
@@ -16,9 +16,9 @@
 
 package com.xiaomi.duckling.dimension.time.helper
 
-import com.google.common.collect.{ImmutableListMultimap, ImmutableMap}
-
+import com.google.common.collect.{ImmutableListMultimap, ImmutableMap, Maps}
 import java.time.DayOfWeek._
+
 import scala.collection.mutable
 
 import com.xiaomi.duckling.Types._
@@ -263,7 +263,7 @@ class LocalHolidayProvider extends HolidayProvider {
     }
   }
 
-  def build(holidayList: List[(Token, String, String)]): (ImmutableMap[String, Token], ImmutableListMultimap[String, String]) = {
+  def build(holidayList: List[(Token, String, String)]): (ImmutableMap[String, Token], java.util.TreeMap[String, String]) = {
     val tokenMap = mutable.Map[String, Token]()
     val normalMap = mutable.Map[String, mutable.Set[String]]()
     holidayList.foreach{
@@ -277,19 +277,19 @@ class LocalHolidayProvider extends HolidayProvider {
         }
     }
 
-    val builder = ImmutableListMultimap.builder[String, String]()
+    val builder = Maps.newTreeMap[String, String]()
     normalMap.foreach{
       case (pt, normalSet) => normalSet.foreach(normal => builder.put(pt, normal))
     }
     val tokenMapBuilder = ImmutableMap.builder[String, Token]()
     tokenMap.toMap.foreach{case (k, v) => tokenMapBuilder.put(k, v)}
 
-    (tokenMapBuilder.build(), builder.build())
+    (tokenMapBuilder.build(), builder)
   }
 
   val (tokenMap, dictBuilder) = build(rulePeriodicHolidays ++ LunarDays.rulePeriodicHolidays)
 
-  override def dict: Dict = Dict(dictBuilder)
+  override def dict: Dict = new Dict(dictBuilder, false)
 
   override def holidayTokenMap: ImmutableMap[String, Token] = tokenMap
 }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/helper/SolarTermProvider.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/helper/SolarTermProvider.scala
@@ -16,8 +16,7 @@
 
 package com.xiaomi.duckling.dimension.time.helper
 
-import com.google.common.collect.{ImmutableListMultimap, ImmutableTable, Table}
-
+import com.google.common.collect.{ImmutableListMultimap, ImmutableTable, Maps, Table}
 import java.time.LocalDate
 
 import com.xiaomi.duckling.Resources
@@ -71,34 +70,35 @@ class LocalSolarTermProvider extends SolarTermProvider {
     */
   override def solarTermTable: Table[Int, String, LocalDate] = table
 
-  private val mmap = ImmutableListMultimap
-    .builder()
-    .put("立春", "立春")
-    .put("雨水", "雨水")
-    .put("惊蛰", "惊蛰")
-    .put("春分", "春分")
-    .put("清明节", "清明")
-    .put("清明", "清明")
-    .put("谷雨", "谷雨")
-    .put("立夏", "立夏")
-    .put("小满", "小满")
-    .put("芒种", "芒种")
-    .put("夏至", "夏至")
-    .put("小暑", "小暑")
-    .put("大暑", "大暑")
-    .put("立秋", "立秋")
-    .put("处暑", "处暑")
-    .put("白露", "白露")
-    .put("秋分", "秋分")
-    .put("寒露", "寒露")
-    .put("霜降", "霜降")
-    .put("立冬", "立冬")
-    .put("小雪", "小雪")
-    .put("大雪", "大雪")
-    .put("冬至", "冬至")
-    .put("小寒", "小寒")
-    .put("大寒", "大寒")
-    .build()
+  private val mmap = {
+    val builder = Maps.newTreeMap[String, String]()
+    builder.put("立春", "立春")
+    builder.put("雨水", "雨水")
+    builder.put("惊蛰", "惊蛰")
+    builder.put("春分", "春分")
+    builder.put("清明节", "清明")
+    builder.put("清明", "清明")
+    builder.put("谷雨", "谷雨")
+    builder.put("立夏", "立夏")
+    builder.put("小满", "小满")
+    builder.put("芒种", "芒种")
+    builder.put("夏至", "夏至")
+    builder.put("小暑", "小暑")
+    builder.put("大暑", "大暑")
+    builder.put("立秋", "立秋")
+    builder.put("处暑", "处暑")
+    builder.put("白露", "白露")
+    builder.put("秋分", "秋分")
+    builder.put("寒露", "寒露")
+    builder.put("霜降", "霜降")
+    builder.put("立冬", "立冬")
+    builder.put("小雪", "小雪")
+    builder.put("大雪", "大雪")
+    builder.put("冬至", "冬至")
+    builder.put("小寒", "小寒")
+    builder.put("大寒", "大寒")
+    builder
+  }
 
-  override def dict = Dict(mmap)
+  override def dict = new Dict(mmap, false)
 }

--- a/duckling-fork-chinese/project/Dependencies.scala
+++ b/duckling-fork-chinese/project/Dependencies.scala
@@ -78,6 +78,7 @@ object Dependencies {
   lazy val java8 = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
   lazy val lunar = "com.github.heqiao2010" % "lunar" % "1.5"
   lazy val emoji = "com.vdurmont" % "emoji-java" % "5.1.1"
+  lazy val trie = "com.hankcs" % "aho-corasick-double-array-trie" % "1.2.2"
 
   //web
   lazy val spThymeleaf = "org.springframework.boot" % "spring-boot-starter-thymeleaf" % "2.4.5"


### PR DESCRIPTION
1. 更新词典匹配为AC自动机前缀匹配
2. 增加最大匹配选项，避免 [xiao, xia, o] 匹配 xiao时出现3个结果


已知问题：词典匹配的时候未考虑词的界限，会出现 hao 与 ahao 匹配的情况，这一问题将在后面解决（匹配时引入边界信息）
