### PR TITLE
[DUCK] 修复 一小时零九分 和 1小时9分

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/seq/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/seq/Rules.scala
@@ -25,7 +25,7 @@ import com.xiaomi.duckling.dimension.numeral.{CNDigit, CapitalCNDigit}
 
 trait Rules extends DimRules {
   val cn = Rule(
-    name = "cn digit sequence",
+    name = "cn digit sequence1",
     pattern = List(s"($CNDigit{2,}|$CapitalCNDigit{2,})".regex),
     prod = singleRegexMatch {
       case text =>
@@ -35,7 +35,7 @@ trait Rules extends DimRules {
   )
 
   val cn1less = Rule(
-    name = "cn digit sequence",
+    name = "cn digit sequence2",
     pattern = List(s"($CNDigit{2,}(?=$CNDigit)|$CapitalCNDigit{2,}(?=$CapitalCNDigit))".regex),
     prod = singleRegexMatch {
       case text =>

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/seq/package.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/seq/package.scala
@@ -33,7 +33,7 @@ package object seq {
   }
 
   def isDigitLeading0: Predicate = {
-    case Token(DigitSequence, DigitSequenceData(s, zh, _)) => s.startsWith("0") && !zh
+    case Token(DigitSequence, DigitSequenceData(s, zh, _)) => s.startsWith("0")
   }
 
   def isDigitLengthGt(n: Int): Predicate = {

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Rules.scala
@@ -25,7 +25,7 @@ import com.xiaomi.duckling.dimension.matcher.{GroupMatch, RegexMatch}
 import com.xiaomi.duckling.dimension.ordinal.{Ordinal, OrdinalData}
 import com.xiaomi.duckling.dimension.time.Helpers._
 import com.xiaomi.duckling.dimension.time.Prods._
-import com.xiaomi.duckling.dimension.time.duration.{Duration, DurationData}
+import com.xiaomi.duckling.dimension.time.duration.{isNotLatentDuration, Duration, DurationData}
 import com.xiaomi.duckling.dimension.time.enums.{Grain, Hint, IntervalDirection}
 import com.xiaomi.duckling.dimension.time.enums.Grain._
 import com.xiaomi.duckling.dimension.time.enums.Hint._
@@ -211,9 +211,9 @@ trait Rules extends DimRules {
     */
   val ruleLastNextNCycle = Rule(
     name = "recent/last/next <duration>",
-    pattern = List(RecentPattern.regex, isDimension(Duration).predicate),
+    pattern = List(RecentPattern.regex, isNotLatentDuration.predicate),
     prod = tokens {
-      case Token(_, GroupMatch(s :: _)) :: Token(Duration, DurationData(v, g, _, fuzzy)) :: _ =>
+      case Token(_, GroupMatch(s :: _)) :: Token(Duration, DurationData(v, g, false, fuzzy)) :: _ =>
         // 月必须是x个月
         s match {
           case "下" | "后" | "接下来" | "未来" | "今后" | "之后" | "向后" | "往后" =>
@@ -259,9 +259,9 @@ trait Rules extends DimRules {
     */
   val ruleNCycleNextLast1 = Rule(
     name = "n <cycle> next/last 1: <duration> 之后",
-    pattern = List(isDimension(Duration).predicate, "((之|以)?(后|前))|过后".regex),
+    pattern = List(isNotLatentDuration.predicate, "((之|以)?(后|前))|过后".regex),
     prod = tokens {
-      case Token(Duration, DurationData(v, grain, _, _)) :: Token(_, GroupMatch(s :: _)) :: _ =>
+      case Token(Duration, DurationData(v, grain, false, _)) :: Token(_, GroupMatch(s :: _)) :: _ =>
         val offset = if (s.endsWith("后")) v else -v
         tt(cycleNth(grain, offset, NoGrain))
     }
@@ -272,7 +272,7 @@ trait Rules extends DimRules {
     */
   val ruleNCycleNext2 = Rule(
     name = "n <cycle> next/last: 过 <duration>",
-    pattern = List("过".regex, isDimension(Duration).predicate),
+    pattern = List("过".regex, isNotLatentDuration.predicate),
     prod = tokens {
       case _ :: Token(Duration, DurationData(v, grain, _, _)) :: _ =>
         tt(cycleNth(grain, v, NoGrain))
@@ -284,7 +284,7 @@ trait Rules extends DimRules {
     */
   val ruleNCycleNext3 = Rule(
     name = "n <cycle> next/last 3:过 <duration> 之后",
-    pattern = List("过".regex, isDimension(Duration).predicate, "之?(后|前)".regex),
+    pattern = List("过".regex, isNotLatentDuration.predicate, "之?(后|前)".regex),
     prod = tokens {
       case _ :: Token(Duration, DurationData(v, grain, _, _)) :: _ =>
         tt(cycleNth(grain, v, NoGrain))
@@ -296,7 +296,7 @@ trait Rules extends DimRules {
     */
   val ruleDurationIntersectTime = Rule(
     name = "<duration> before/after <time>",
-    pattern = List(isDimension(Duration).predicate, "之?(前|后)的?".regex, isNotLatent.predicate),
+    pattern = List(isNotLatentDuration.predicate, "之?(前|后)的?".regex, isNotLatent.predicate),
     prod = tokens {
       case Token(Duration, DurationData(v, g, _, _)) :: Token(_, GroupMatch(_ :: s :: _)) ::
         Token(Time, td: TimeData) :: _ =>
@@ -367,7 +367,7 @@ trait Rules extends DimRules {
     */
   val ruleInAInterval = Rule(
     name = "in a <duration>",
-    pattern = List(isDimension(Duration).predicate, "内".regex),
+    pattern = List(isNotLatentDuration.predicate, "内".regex),
     prod = tokens {
       case Token(Duration, DurationData(value, grain, _, _)) :: _ =>
         tt(cycleN(notImmediate = false, grain, value, NoGrain))
@@ -449,7 +449,7 @@ trait Rules extends DimRules {
   val ruleSequence3 = Rule(
     name = "sequence3: <recent nominal> <duration>",
     pattern =
-      List(isHint(RecentNominal).predicate, "(往|向|之)?(前|后)的?".regex, isDimension(Duration).predicate),
+      List(isHint(RecentNominal).predicate, "(往|向|之)?(前|后)的?".regex, isNotLatentDuration.predicate),
     prod = tokens {
       case Token(_, td1: TimeData) :: Token(_, GroupMatch(_ :: s :: _)) :: Token(
             _,

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/Examples.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/Examples.scala
@@ -28,6 +28,7 @@ trait Examples extends DimExamples {
     (DurationData(185, Minute), List("3小时05分", "三小时零五分钟")),
     (DurationData(90, Second), List("1分半", "1分半钟")),
     (DurationData(2, Minute), List("2分钟", "两分钟", "二分钟")),
+    (DurationData(69, Minute), List("1小时09分", "1小时9分", "一小时零九分", "一小时九分")),
     (DurationData(30, Day), List("30天")),
     (DurationData(7, Week), List("七周")),
     (DurationData(1, Month), List("一个月")),

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/Rules.scala
@@ -55,10 +55,10 @@ trait Rules extends DimRules {
         // 一九八七 年 不召回
         not(isCnSequence)
       ).predicate,
-      isNotLatentGrain.predicate
+      isDimension(TimeGrain).predicate
     ),
     prod = tokens {
-      case t1 :: Token(TimeGrain, GrainData(g, _)) :: _ =>
+      case t1 :: Token(TimeGrain, GrainData(g, latent)) :: _ =>
         if (isDimension(UnitNumber)(t1) && !compatibleWithUnitNumber(g)) None
         else {
           if (isDimension(Numeral)(t1) && g == Month) None
@@ -68,7 +68,7 @@ trait Rules extends DimRules {
                 val n = math.floor(v).toInt
                 // 2012年 不召回, 两千年召回
                 if (seq.nonEmpty && g == Year && 1950 <= n && n <= 2050) None
-                else tt(n, g)
+                else Token(Duration, DurationData(n, g, latent = latent))
               case _ => None
             }
           }
@@ -164,7 +164,7 @@ trait Rules extends DimRules {
       isNatural.predicate,
       isDimension(TimeGrain).predicate,
       "(零|外加|加上|加)".regex,
-      isDimension(Duration).predicate
+      isNotLatentDuration.predicate
     ),
     prod = tokens {
       case t1 :: Token(TimeGrain, GrainData(g, _)) :: _ :: Token(_, dd@DurationData(_, dg, _, _)) :: _

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/package.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/package.scala
@@ -58,7 +58,7 @@ package object duration {
     case Token(TimeGrain, GrainData(Month, _)) => true
   }
 
-  def isNotLatentGrain: Predicate = {
-    case Token(TimeGrain, GrainData(_, latent)) => !latent
+  def isNotLatentDuration: Predicate = {
+    case Token(Duration, DurationData(_, _, latent, _)) => !latent
   }
 }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/package.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/duration/package.scala
@@ -61,4 +61,12 @@ package object duration {
   def isNotLatentDuration: Predicate = {
     case Token(Duration, DurationData(_, _, latent, _)) => !latent
   }
+
+  def isFuzzyNotLatentDuration: Predicate = {
+    case Token(Duration, DurationData(_, _, _, fuzzy)) => fuzzy
+  }
+
+  def isNotLatentGrain: Predicate = {
+    case Token(TimeGrain, GrainData(_, latent)) => !latent
+  }
 }


### PR DESCRIPTION
Closes #111 

错误修复
1. 一小时零五分，零五 在leadingZero的判断中被滤掉，恢复，**需要看看之前是考虑的什么情况**
2. 一小时五分，五分是一个latent表达，这里允许生成latent，并在之前使用Duration的地方都加上了不为latent的条件，使得条件的整体使用范围并不会扩大。

@zhangsonglei 方便地话，做一个前后对比是比较好的。