### PR TITLE
[DUCK] 子选项参数使用无参Java Bean重做，提升兼容性

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Numeral.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Numeral.scala
@@ -16,6 +16,8 @@
 
 package com.xiaomi.duckling.dimension.numeral
 
+import scala.beans.BooleanBeanProperty
+
 import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.Dimension
 import com.xiaomi.duckling.dimension.implicits._
@@ -53,16 +55,26 @@ case class NumeralData(value: Double,
 }
 
 /**
- *
- * @param allowZeroLeadingDigits 允许000318解析为318
- * @param cnSequenceAsNumber     允许一二三四解析出1234
- * @param dialectSupport         允许识别方言中的"俩仨"
- * @param KMG_Support            允许识别类似"10k"为"10,000"
+ * 数字解析的额外参数，控制一些可选行为
  */
-case class NumeralOptions(allowZeroLeadingDigits: Boolean = false,
-                          cnSequenceAsNumber: Boolean = false,
-                          dialectSupport: Boolean = false,
-                          KMG_Support: Boolean = true)
+class NumeralOptions {
+  /**
+   * 允许000318解析为318
+   */
+  @BooleanBeanProperty var allowZeroLeadingDigits: Boolean = false
+  /**
+   * 允许一二三四解析出1234
+   */
+  @BooleanBeanProperty var cnSequenceAsNumber: Boolean = false
+  /**
+   * 允许识别方言中的"俩仨"
+   */
+  @BooleanBeanProperty var dialectSupport: Boolean = false
+  /**
+   * 允许识别类似"10k"为"10,000"
+   */
+  @BooleanBeanProperty var KMG_Support: Boolean = true
+}
 
 trait IntervalValue extends ResolvedValue
 

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Time.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Time.scala
@@ -16,6 +16,8 @@
 
 package com.xiaomi.duckling.dimension.time
 
+import scala.beans.BooleanBeanProperty
+
 import com.typesafe.scalalogging.LazyLogging
 
 import com.xiaomi.duckling.Types._
@@ -63,20 +65,30 @@ case object Time extends Dimension with Rules {
 }
 
 /**
-  * 时间解析的额外参数，适应一些语义模糊的情况
-  *
-  * @param resetTimeOfDay 上午是否总是需要指今天的上午，默认是未来一个上午
-  * @param recentInFuture 最近是向前计算还是向后计算，默认是未来
-  * @param alwaysInFuture 对于过去的日期是否取未来一年的日期
-  * @param inheritGrainOfDuration 继承来自持续时间的粒度，比如"三天后"，返回天级
-  * @param parseFourSeasons 解析春夏秋冬四季/输出结果以节气为参照
-  *
-  */
-case class TimeOptions(resetTimeOfDay: Boolean = false,
-                       recentInFuture: Boolean = true,
-                       alwaysInFuture: Boolean = true,
-                       inheritGrainOfDuration: Boolean = false,
-                       parseFourSeasons: Boolean = false)
+ * 时间解析的额外参数，适应一些语义模糊的情况
+ */
+class TimeOptions {
+  /**
+   * 上午是否总是需要指今天的上午，默认是未来一个上午
+   */
+  @BooleanBeanProperty var resetTimeOfDay: Boolean = false
+  /**
+   * 最近是向前计算还是向后计算，默认是未来
+   */
+  @BooleanBeanProperty var recentInFuture: Boolean = true
+  /**
+   * 对于过去的日期是否取未来一年的日期
+   */
+  @BooleanBeanProperty var alwaysInFuture: Boolean = true
+  /**
+   * 继承来自持续时间的粒度，比如"三天后"，返回天级
+   */
+  @BooleanBeanProperty var inheritGrainOfDuration: Boolean = false
+  /**
+   * 解析春夏秋冬四季/输出结果以节气为参照
+   */
+  @BooleanBeanProperty var parseFourSeasons: Boolean = false
+}
 
 case class TimeData(timePred: TimePredicate,
                     latent: Boolean = false,

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/Testing.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/ranking/Testing.scala
@@ -13,5 +13,9 @@ object Testing {
       referenceTime = ZonedDateTime.of(LocalDateTime.of(2013, 2, 12, 4, 30, 0), ZoneCN)
     )
 
-  val testOptions: Options = Options(full = true, debug = true, timeOptions = TimeOptions(parseFourSeasons = true))
+  val testOptions: Options = {
+    val timeOpts = new TimeOptions()
+    timeOpts.setParseFourSeasons(true)
+    Options(full = true, debug = true, timeOptions = timeOpts)
+  }
 }

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/numeral/NumeralTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/numeral/NumeralTest.scala
@@ -17,7 +17,6 @@
 package com.xiaomi.duckling.dimension.numeral
 
 import com.xiaomi.duckling.Api.analyze
-import com.xiaomi.duckling.Types.RankOptions
 import com.xiaomi.duckling.dimension.numeral.Predicates._
 import com.xiaomi.duckling.dimension.numeral.fraction.{Fraction, FractionData}
 import com.xiaomi.duckling.dimension.ordinal.{Ordinal, OrdinalData}
@@ -26,11 +25,11 @@ import com.xiaomi.duckling.UnitSpec
 
 class NumeralTest extends UnitSpec {
 
-  val options = testOptions.copy(
-    targets = Set(Numeral),
-    full = false,
-    rankOptions = RankOptions(combinationRank = true)
-  )
+  val options = {
+    val opts = testOptions.copy(targets = Set(Numeral), full = false)
+    opts.rankOptions.setCombinationRank(true)
+    opts
+  }
 
   describe("NumeralTest") {
     val cases = Table(
@@ -153,7 +152,9 @@ class NumeralTest extends UnitSpec {
 
   describe("NumeralOptionsTest") {
     it("KMG Support") {
-      val opts0 = testOptions.copy(targets = Set(Numeral), full = false, numeralOptions = NumeralOptions(KMG_Support = false))
+      val numeralOptions = new NumeralOptions()
+      numeralOptions.setKMG_Support(false)
+      val opts0 = testOptions.copy(targets = Set(Numeral), full = false, numeralOptions = numeralOptions)
       val answers0 = analyze("1.2G", testContext, opts0)
       answers0(0).token.value match {
         case data: NumeralValue => data.n should be
@@ -161,7 +162,8 @@ class NumeralTest extends UnitSpec {
         case _ => true shouldBe (false)
       }
 
-      val opts1 = testOptions.copy(targets = Set(Numeral), full = false, numeralOptions = NumeralOptions(KMG_Support = true))
+      numeralOptions.setKMG_Support(true)
+      val opts1 = testOptions.copy(targets = Set(Numeral), full = false, numeralOptions = numeralOptions)
       val answers1 = analyze("1.2G", testContext, opts1)
       answers1(0).token.value match {
         case data: NumeralValue => data.n should be

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/package.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/package.scala
@@ -24,7 +24,11 @@ import com.xiaomi.duckling.types.Node
 package object dimension {
   def blankNode(s: Int, e: Int) = Node(Range(s, e), null, null, null, null)
 
-  private val rankOptions = RankOptions(winnerOnly = false)
+  private val rankOptions = {
+    val opts = new RankOptions()
+    opts.setWinnerOnly(false)
+    opts
+  }
 
   def answerSize(sentence: String, targets: Set[Dimension]): Int = {
     val options = testOptions.copy(rankOptions = rankOptions, targets = targets)

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeDataTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeDataTest.scala
@@ -56,7 +56,8 @@ class TimeDataTest extends UnitSpec with LazyLogging {
     )
 
     it("not InFuture eq") {
-      val timeOptions = TimeOptions(alwaysInFuture = false)
+      val timeOptions = new TimeOptions()
+      timeOptions.setAlwaysInFuture(false)
       val options = testOptions.copy(targets = Set(Time), timeOptions = timeOptions)
 
       testCases.foreach {
@@ -88,13 +89,14 @@ class TimeDataTest extends UnitSpec with LazyLogging {
           .asInstanceOf[SimpleValue].instant
       }
 
-      val options1 = options.withTimeOptions(new TimeOptions(inheritGrainOfDuration = false))
-      val t1 = parse("三分钟后", options1)
+      options.timeOptions.setInheritGrainOfDuration(false)
+      val t1 = parse("三分钟后", options)
       t1.grain should (be(Grain.NoGrain) or be(Grain.Second))
       t1.datetime.toString should be ("2022-10-01 00:03:05 [+08:00]")
 
-      val options2 = options.withTimeOptions(new TimeOptions(inheritGrainOfDuration = true))
-      val t2 = parse("三分钟后", options2)
+
+      options.timeOptions.setInheritGrainOfDuration(true)
+      val t2 = parse("三分钟后", options)
       t2.grain shouldBe Grain.Minute
       t2.datetime.toString should be ("2022-10-01 00:03:00 [+08:00]")
     }

--- a/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeTest.scala
+++ b/duckling-fork-chinese/core/src/test/scala/com/xiaomi/duckling/dimension/time/TimeTest.scala
@@ -31,8 +31,11 @@ import com.xiaomi.duckling.UnitSpec
 class TimeTest extends UnitSpec {
 
   private val options = testOptions.copy(targets = Set(Time))
-  private val combinationOptions =
-    options.copy(rankOptions = RankOptions(combinationRank = true), full = false)
+  private val combinationOptions = {
+    val rankOptions = new RankOptions()
+    rankOptions.setCombinationRank(true)
+    options.copy(rankOptions = rankOptions, full = false)
+  }
 
   describe("single case") {
     val opt = options.copy(full = false)

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/ranking/AnswersSelection.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/ranking/AnswersSelection.scala
@@ -120,8 +120,8 @@ object AnswersSelection extends LazyLogging {
   }
 
   def makeDataset1(sentence: String, target: String, dim: Dimension): List[Datum] = {
-    val options =
-      Options(withLatent = false, targets = Set(dim), rankOptions = RankOptions(winnerOnly = false))
+    val options = Options(withLatent = false, targets = Set(dim))
+    options.rankOptions.setWinnerOnly(false)
     val answers = Api.analyze(sentence, testContext, options)
 
     // 寻找可能的组合
@@ -153,8 +153,7 @@ object AnswersSelection extends LazyLogging {
   }
 
   def parse(sentence: String, dim: Dimension) = {
-    val options =
-      Options(withLatent = false, rankOptions = RankOptions(), targets = Set(dim))
+    val options = Options(withLatent = false, targets = Set(dim))
     val answers = Api.analyze(sentence, testContext, options)
 
     // 寻找可能的组合

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/AnswerSizeDetector.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/AnswerSizeDetector.scala
@@ -24,7 +24,7 @@ import org.json4s.jackson.Serialization.write
 import com.xiaomi.duckling.Api
 import com.xiaomi.duckling.Api.formatToken
 import com.xiaomi.duckling.JsonSerde._
-import com.xiaomi.duckling.Types.{Context, Options, RankOptions}
+import com.xiaomi.duckling.Types.{Context, Options}
 import com.xiaomi.duckling.dimension.RuleSets
 
 object AnswerSizeDetector {
@@ -32,8 +32,8 @@ object AnswerSizeDetector {
     val Array(dims, query) = args
     val targets = dims.split(",").map(RuleSets.namedDimensions).toSet
 
-    val options = Options(withLatent = false, full = false,
-      rankOptions = RankOptions(winnerOnly = false), targets = targets)
+    val options = Options(withLatent = false, targets = targets)
+    options.rankOptions.setWinnerOnly(false)
     val context = Context(ZonedDateTime.now(), Locale.CHINA)
 
     Api.analyze("123", context, options)

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/NaiveBayesConsole.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/NaiveBayesConsole.scala
@@ -35,21 +35,20 @@ import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.RuleSets
 import com.xiaomi.duckling.dimension.implicits._
 import com.xiaomi.duckling.dimension.matcher._
-import com.xiaomi.duckling.dimension.numeral.NumeralOptions
-import com.xiaomi.duckling.dimension.time.TimeOptions
 import com.xiaomi.duckling.ranking.Ranker
 import com.xiaomi.duckling.ranking.Testing.testContext
 import com.xiaomi.duckling.types.Node
 
 /**
-  * sbt duckConsole的jline启动有点问题，可以使用sbt console
-  * @example <p>sbt core/console
-  *          <p>> com.xiaomi.duckling.task.NaiveBayesConsole.run()
-  *          <p>> dimension time duration
-  *          <p>> 今天的天气
-  *          <p>> option with-latent false
-  *          <p>...
-  */
+ * sbt duckConsole的jline启动有点问题，可以使用sbt console
+ *
+ * @example <p>sbt core/console
+ *          <p>> com.xiaomi.duckling.task.NaiveBayesConsole.run()
+ *          <p>> dimension time duration
+ *          <p>> 今天的天气
+ *          <p>> option with-latent false
+ *          <p>...
+ */
 object NaiveBayesConsole extends LazyLogging {
   private val context = testContext.copy(referenceTime = ZonedDateTime.now(ZoneCN))
 
@@ -113,20 +112,13 @@ object NaiveBayesConsole extends LazyLogging {
       } else if (line.startsWith("option ")) {
         val opt =
           if (cols.length >= 3 && Set("true", "false")
-                .contains(cols(2).toLowerCase)) {
+            .contains(cols(2).toLowerCase)) {
             val value = cols(2).toBoolean
             val opt = cols(1) match {
-              case "winner-only" =>
-                options.withRankOptions(
-                  options.rankOptions.copy(winnerOnly = value)
-                )
+              case "winner-only" => options.rankOptions.setWinnerOnly(value); options
               case "with-latent" => options.copy(withLatent = value)
-              case "full"        => options.copy(full = value)
-              case "inherit-duration-grain" =>
-                options.withTimeOptions(
-                  timeOptions =
-                    options.timeOptions.copy(inheritGrainOfDuration = value)
-                )
+              case "full" => options.copy(full = value)
+              case "inherit-duration-grain" => options.timeOptions.setInheritGrainOfDuration(value); options
               case _ => options
             }
             opt
@@ -175,20 +167,16 @@ object NaiveBayesConsole extends LazyLogging {
   }
 
   def run(): Unit = {
-    var options = Options(
-      targets = Set(),
-      withLatent = false,
-      rankOptions = RankOptions(
-        ranker = Ranker.NaiveBayes,
-        winnerOnly = true,
-        combinationRank = false
-      ),
-      timeOptions = TimeOptions(resetTimeOfDay = false, recentInFuture = true),
-      numeralOptions = NumeralOptions(
-        allowZeroLeadingDigits = false,
-        cnSequenceAsNumber = false
-      )
-    )
+    var options = Options(targets = Set(), withLatent = false)
+    options.rankOptions.setRanker(Ranker.NaiveBayes)
+    options.rankOptions.setWinnerOnly(true)
+    options.rankOptions.setCombinationRank(false)
+
+    options.timeOptions.setResetTimeOfDay(false)
+    options.timeOptions.setRecentInFuture(true)
+
+    options.numeralOptions.setAllowZeroLeadingDigits(false)
+    options.numeralOptions.setCnSequenceAsNumber(false)
 
     // 初始化分类器
     Api.analyze("今天123", context, options)

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/NaiveBayesDebug.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/task/NaiveBayesDebug.scala
@@ -24,9 +24,6 @@ import com.xiaomi.duckling.Api.formatToken
 import com.xiaomi.duckling.JsonSerde._
 import com.xiaomi.duckling.Types._
 import com.xiaomi.duckling.dimension.RuleSets
-import com.xiaomi.duckling.dimension.implicits._
-import com.xiaomi.duckling.dimension.numeral.NumeralOptions
-import com.xiaomi.duckling.dimension.time.TimeOptions
 import com.xiaomi.duckling.ranking.Ranker
 import com.xiaomi.duckling.ranking.Testing.testContext
 
@@ -50,15 +47,16 @@ object NaiveBayesDebug {
   def main(args: Array[String]): Unit = {
     val Array(dim, sentence) = args
     val targets = dim.split(",").map(s => RuleSets.namedDimensions(s.toLowerCase())).toSet
-    val options = Options(
-      targets = targets,
-      withLatent = false,
-      full = true,
-      rankOptions =
-        RankOptions(ranker = Ranker.NaiveBayes, winnerOnly = true, combinationRank = false, rangeRankAhead = false),
-      timeOptions = TimeOptions(resetTimeOfDay = false, recentInFuture = true, alwaysInFuture = true),
-      numeralOptions = NumeralOptions(allowZeroLeadingDigits = false, cnSequenceAsNumber = false)
-    )
+    val options = Options(targets = targets, withLatent = false, full = true)
+    options.rankOptions.setRanker(Some(Ranker.NaiveBayes))
+    options.rankOptions.setWinnerOnly(true)
+    options.rankOptions.setCombinationRank(false)
+    options.rankOptions.setRangeRankAhead(false)
+    options.timeOptions.setResetTimeOfDay(false)
+    options.timeOptions.setRecentInFuture(true)
+    options.timeOptions.setAlwaysInFuture(true)
+    options.numeralOptions.setAllowZeroLeadingDigits(false)
+    options.numeralOptions.setCnSequenceAsNumber(false)
 
     // 初始化分类器
     if (options.rankOptions.ranker.nonEmpty) Api.analyze("今天123", context, options)

--- a/duckling-fork-chinese/server/src/main/scala/com/xiaomi/duckling/server/DucklingController.java
+++ b/duckling-fork-chinese/server/src/main/scala/com/xiaomi/duckling/server/DucklingController.java
@@ -47,8 +47,6 @@ public class DucklingController {
         } else {
             options = new Options(DEFAULT_DIMENSION_LIST, false);
         }
-        options = options.withNumeralOptions(new NumeralOptions(false, false, true, true))
-            .withTimeout(-1);
         return Api.analyzeJ(text, new Context(ZonedDateTime.now(), Locale.CHINA), options);
     }
 


### PR DESCRIPTION
- ！这是为了后续兼容性考虑的非兼容修改
- 子选项使用java bean来承载，这样就能做到向前/后兼容了，避开了在增加参数后，由于使用全参构造函数带来的参数个数不匹配的问题
- 好处：在升级duckling后，旧代码不会再因为引入的新参数未设置而报错（全参构造函数变了）