### PR TITLE
[DUCK] 新增说法支持明天上午8到9点，支持中午11点等

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/predicates.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/predicates.scala
@@ -195,6 +195,20 @@ object predicates {
     case Token(_, td: TimeData) => td.form.contains(Weekend)
   }
 
+  def xGrain(grain: Grain): Predicate = {
+    case Token(_, td: TimeData) =>
+      td.timePred match {
+        case TimeDatePredicate(None, None, hour, None, None, dayOfMonth, month, None, None) =>
+          (grain, hour, dayOfMonth, month) match {
+            case (Hour, Some(h), None, None) => true
+            case (Day, None, Some(d), None) => true
+            case (Month, None, None, Some(m)) => true
+            case _ => false
+          }
+        case _ => false
+      }
+  }
+
   val isNotLatent: Predicate = {
     case Token(_, td: TimeData) => !td.latent
   }

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/Examples.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/Examples.scala
@@ -358,7 +358,7 @@ object Examples extends DimExamples {
         LocalDateTime.of(2013, 2, 12, 18, 0, 0),
         Hour
       ),
-      List("下午三点到6点", "中午3点到6点")
+      List("下午三点到6点", "中午3点到6点", "下午3到6点")
     ),
     (
       localDateTimeInterval(


### PR DESCRIPTION
新增说法支持
- 3到5号
- 八到九点
- 明天上午八到九点

增加不合理表达的支持（只在与小时求交时生效），比如
- 中午11点
- 早上3点
- 上午5点