### PR TITLE
FIX取消有歧义的农历表达，解决小数负值表达value错误问题

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/numeral/Rules.scala
@@ -105,7 +105,7 @@ trait Rules extends DimRules {
           }
 
           fractionPart.map { p =>
-            val v = intPart + p
+            val v = if (intPart >= 0) intPart + p else intPart - p
             token(NumeralData(v, composable = false, precision = precision))
           }
       }

--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/date/LunarDates.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/date/LunarDates.scala
@@ -45,20 +45,6 @@ object LunarDates {
     }
   )
   
-  val ruleLunarSymbolDate2 = Rule(
-    name = "<day> <lunar>",
-    pattern = List(
-      // 避免农历八月初八按[农历]八月初八和[农历八月]初八结合两次
-      and(isTimeDatePredicate, isNotHint(Hint.Intersect), isNotHint(Hint.YearMonth)).predicate,
-      "的?(农|阴)历".regex
-    ),
-    prod = tokens {
-      case Token(Date, td: TimeData) :: _ =>
-        val t = lunar(td).copy(calendar = Lunar(false), hint = Hint.Lunar)
-        Token(Date, t)
-    }
-  )
-
   val ruleLunarMonth = Rule(
     name = "<lunar-month> 正/腊/冬",
     pattern = List("闰?(正|腊|冬)月".regex),
@@ -97,5 +83,5 @@ object LunarDates {
     }
   )
 
-  val rules = List(ruleLunarSymbolDate1, ruleLunarSymbolDate2, ruleLunarMonth, ruleLunarDayOfMonth)
+  val rules = List(ruleLunarSymbolDate1, ruleLunarMonth, ruleLunarDayOfMonth)
 }

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/numeral/Examples.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/numeral/Examples.scala
@@ -76,7 +76,8 @@ object Examples extends DimExamples {
     ((1.45, 2), List("1点45")),
     ((1.4, 1), List("一点四")),
     ((1987.43, 2), List("一千九百八十七点四三")),
-    ((123.123, 3), List("123.123"))
+    ((123.123, 3), List("123.123")),
+    ((-100.3, 1), List("负一百点三"))
   )
 
   override def pairs: List[(ResolvedValue, List[String])] = {

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/date/Examples.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/date/Examples.scala
@@ -54,7 +54,7 @@ object Examples extends DimExamples {
     (ym(2001, 5), List("零一年五月")),
     (ymd(2013, 2, 28), List("月底")),
     // 2013.2.12 农历是 2013年正月初三 => 2014年正月初二
-    (ymd(2014, 1, 2, calendar = Lunar(false)), List("农历一月初二", "正月初二", "农历的一月初二", "阴历的正月初二", "一月初二农历", "一月初二的农历")),
+    (ymd(2014, 1, 2, calendar = Lunar(false)), List("农历一月初二", "正月初二", "农历的一月初二", "阴历的正月初二")),
     (ymd(2013, 1, 18, calendar = Lunar(false)), List("农历一月十八", "正月十八")),
     (ymd(2013, 11, 8, calendar = Lunar(false)), List("农历十一月初八", "冬月初八")),
     (ymd(2013, 11, 22, calendar = Lunar(false)), List("农历十一月二十二", "冬月二十二")),


### PR DESCRIPTION
case1："三月十八农历"提醒我xxx【农历的三月十八】；"三月十八农历"是几月几号【三月十八对应的农历日期】  
case2：负一百点三，预期：-100.3，实际：-99.7