### PR TITLE
IMP修改【duration+内】interval范围等同【未来+duration】

### DIFF
--- a/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Rules.scala
+++ b/duckling-fork-chinese/core/src/main/scala/com/xiaomi/duckling/dimension/time/Rules.scala
@@ -458,10 +458,15 @@ trait Rules extends DimRules {
     */
   val ruleInAInterval = Rule(
     name = "in a <duration>",
-    pattern = List(isNotLatentDuration.predicate, "内".regex),
+    pattern = List(isNotLatentDuration.predicate, "[之以]?内".regex),
     prod = tokens {
       case Token(Duration, DurationData(value, grain, _, _, _)) :: _ =>
-        tt(cycleN(notImmediate = false, grain, value, NoGrain))
+        val (g, v) = grain match {
+          case Month => (Day, value * 30)
+          case Week => (Day, value * 7)
+          case _ => (grain, value)
+        }
+        tt(cycleN(notImmediate = false, g, v))
     }
   )
 

--- a/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/Examples.scala
+++ b/duckling-fork-chinese/learning/src/main/scala/com/xiaomi/duckling/dimension/time/Examples.scala
@@ -106,7 +106,7 @@ object Examples extends DimExamples {
         LocalDateTime.of(2016, 1, 1, 0, 0, 0),
         Year
       ),
-      List("下三年", "未来三年")
+      List("下三年", "未来三年", "三年内")
     ),
     (
       localDateTimeInterval(
@@ -216,7 +216,7 @@ object Examples extends DimExamples {
         LocalDateTime.of(2013, 2, 12, 4, 45, 0),
         Minute
       ),
-      List("未来一刻钟", "之后一刻钟", "向后一刻钟", "往后一刻钟")
+      List("未来一刻钟", "之后一刻钟", "向后一刻钟", "往后一刻钟", "一刻钟以内")
     )
   )
 
@@ -271,7 +271,7 @@ object Examples extends DimExamples {
         LocalDateTime.of(2013, 3, 5, 0, 0, 0),
         Day
       ),
-      List("接下来三周")
+      List("接下来三周", "三周内")
     ),
     (
       localDateTimeInterval(
@@ -279,7 +279,7 @@ object Examples extends DimExamples {
         LocalDateTime.of(2013, 2, 19, 0, 0, 0),
         Day
       ),
-      List("未来一周")
+      List("未来一周", "一周内")
     ),
     (
       datetime(LocalDateTime.of(2013, 3, 5, 4, 30, 0), Second),


### PR DESCRIPTION
修改【duration+内】interval范围等同【未来+duration】。eg，token=三天内：    
当前时间：2023-10-18T11:21:15
原始结果：[2023-10-18T11:21:15, 2023-10-21T11:21:15]
现在结果：[2023-10-18T00:00:00, 2023-10-21T00:00:00]
